### PR TITLE
Location Rule Cleanup

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1004,8 +1004,7 @@
             "name": "Have ancient debris in your inventory.",
             "access_rules": [
               "$bastion, [$nether], [$can_brew_potions], [$bed], $has_diamond_pickaxe",
-              "$nether, [$can_brew_potions], [$bed], $has_diamond_pickaxe",
-              "scraps"
+              "$nether, [$can_brew_potions], [$bed], $has_diamond_pickaxe"
             ],
             "visibility_rules": [
               "showexcluded_off",
@@ -1099,9 +1098,8 @@
           {
             "name": "Have a full set of netherite armor in your inventory.",
             "access_rules": [
-              "$bastion, $scraps, $tools_diamond, [$nether], [$armor_diamond], [$has_all_scraps], [$crafting_ingots], [@Overworld/Diamonds!/Have a diamond in your inventory.], [@Nether/Hidden in the Depths/Have ancient debris in your inventory.], [$include_hard]",
-              "$bastion, $tools_diamond, [$nether], [$armor_diamond], [$has_all_scraps], [$crafting_ingots], [@Overworld/Diamonds!/Have a diamond in your inventory.], [@Nether/Hidden in the Depths/Have ancient debris in your inventory.], [$include_hard]",
-              "$bastion, $tools_diamond, [$nether], [$armor_diamond], [$has_all_scraps], [$crafting_ingots], [@Overworld/Diamonds!/Have a diamond in your inventory.],  @Nether/Hidden in the Depths/Have ancient debris in your inventory. , [$include_hard]"
+              "[$nether], [$armor_diamond], [$has_all_scraps], [$crafting_ingots], [@Overworld/Diamonds!/Have a diamond in your inventory.], [@Nether/Hidden in the Depths/Have ancient debris in your inventory.], [$include_hard]",
+              "$bastion, [$nether], [$armor_diamond], [$has_all_scraps], [$crafting_ingots], [@Overworld/Diamonds!/Have a diamond in your inventory.], [@Nether/Hidden in the Depths/Have ancient debris in your inventory.], [$include_hard]"
             ],
             "visibility_rules": [
               "showexcluded_off,hard_on",
@@ -2252,8 +2250,7 @@
           {
             "name": "Have a netherite hoe in your inventory.",
             "access_rules": [
-              "[$nether], $bastion, @Nether/Hidden in the Depths/Have ancient debris in your inventory., $tools_diamond, [$has_gold]",
-              "[$nether], $bastion, $scraps, $tools_diamond, [@Nether/Hidden in the Depths/Have ancient debris in your inventory.], [$has_gold]",
+              "[$nether], [@Nether/Hidden in the Depths/Have ancient debris in your inventory.], [$has_gold]",
               "[$nether], $bastion, [@Nether/Hidden in the Depths/Have ancient debris in your inventory.], [$has_gold]"
             ],
             "visibility_rules": [

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1098,8 +1098,8 @@
           {
             "name": "Have a full set of netherite armor in your inventory.",
             "access_rules": [
-              "[$nether], [$armor_diamond], [$has_all_scraps], [$crafting_ingots], [@Overworld/Diamonds!/Have a diamond in your inventory.], [@Nether/Hidden in the Depths/Have ancient debris in your inventory.], [$include_hard]",
-              "$bastion, [$nether], [$armor_diamond], [$has_all_scraps], [$crafting_ingots], [@Overworld/Diamonds!/Have a diamond in your inventory.], [@Nether/Hidden in the Depths/Have ancient debris in your inventory.], [$include_hard]"
+              "$nether, $armor_diamond, $has_all_scraps, $crafting_ingots, $has_diamond_pickaxe, $can_brew_potions, $bed, [$include_hard]",
+              "$bastion, [$nether], [$armor_diamond], [$has_all_scraps], [$crafting_ingots], [$has_diamond_pickaxe], [$can_brew_potions], [$bed], [$include_hard]"
             ],
             "visibility_rules": [
               "showexcluded_off,hard_on",
@@ -2250,8 +2250,8 @@
           {
             "name": "Have a netherite hoe in your inventory.",
             "access_rules": [
-              "[$nether], [@Nether/Hidden in the Depths/Have ancient debris in your inventory.], [$has_gold]",
-              "[$nether], $bastion, [@Nether/Hidden in the Depths/Have ancient debris in your inventory.], [$has_gold]"
+              "$nether, $can_brew_potions, $bed, $has_diamond_pickaxe, $has_gold",
+              "$bastion, [$nether], [$can_brew_potions], [$bed], [$has_diamond_pickaxe], [$has_gold]"
             ],
             "visibility_rules": [
               "showexcluded_off",

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1003,8 +1003,8 @@
           {
             "name": "Have ancient debris in your inventory.",
             "access_rules": [
-              "$bastion, [$nether], [$can_brew_potions], [$bed], $has_diamond_pickaxe",
-              "$nether, [$can_brew_potions], [$bed], $has_diamond_pickaxe"
+              "$bastion, [$nether], [$can_brew_potions], [$bed], [$has_diamond_pickaxe]",
+              "$nether, [$can_brew_potions], [$bed], [$has_diamond_pickaxe]"
             ],
             "visibility_rules": [
               "showexcluded_off",


### PR DESCRIPTION
Hidden in the Depths is triggered by having Ancient Debris in your inventory, not Netherite Scrap.
Cover Me in Debris and Serious Dedication currently have incorrect logic rules that don't align perfectly with their physical access. This accounts for that so that they're only shown as available out of logic when their physical access conditions are met, and only shown in logic when their logical access conditions are met.

Tested by toggling various options in the PopTracker and verifying that they matched up with the correct access/logic rules.